### PR TITLE
Add Express backend to persist shared captions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+data/captions.json

--- a/README.md
+++ b/README.md
@@ -1,3 +1,27 @@
 # PiccolaMimì
 
 https://pierazhi.github.io/PiccolaMim-/
+
+## Avvio in locale con backend condiviso
+
+Il progetto ora include un piccolo server Node.js che salva le descrizioni delle foto su disco così che possano essere condivise tra dispositivi diversi.
+
+### Requisiti
+
+* Node.js 18 o superiore
+
+### Installazione dipendenze
+
+```bash
+npm install
+```
+
+### Avvio dell'applicazione
+
+```bash
+npm start
+```
+
+Il comando avvia un server Express su `http://localhost:3000` che serve i file statici della galleria e risponde alle richieste REST su `/api/captions`.
+
+Le descrizioni vengono salvate nel file `data/captions.json` (ignorato da Git). Assicurati di eseguire il server in un ambiente con scrittura abilitata per mantenere i dati.

--- a/index.html
+++ b/index.html
@@ -1454,7 +1454,10 @@
   <script>
 (function(){
   const RANGE={startYear:2019,endYear:2025},WEEK_START=1;
-  let vista=oggiYM(),dati=leggiDaHTML(),giornoSelezionato=null;
+  let vista=oggiYM(),dati={},giornoSelezionato=null;
+  const API_BASE=window.CAPTIONS_API_BASE||'/api';
+  let captionsCache={};
+  let captionsPromise=null;
   const elTestaSett=byId('weekdayHead'),elGriglia=byId('grid'),
         monthSel=byId('monthSel'),yearSel=byId('yearSel'),
         btnPrev=byId('prevMonth'),btnNext=byId('nextMonth'),btnOggi=byId('todayBtn'),
@@ -1467,7 +1470,36 @@
         chiudiFiltro=byId('chiudiFiltro'),filterList=byId('filterList'),filterPhotos=byId('filterPhotos'),
         modal=byId('modal'),modalImg=byId('modalImg');
 
-  renderIntestazioni();initSelettori();caricaDescrizioni();renderCalendario();aggiornaMonthDisplay();
+  window.captionService={
+    async load(){
+      if(!captionsPromise){
+        captionsPromise=caricaDaBackend().catch(err=>{captionsPromise=null;throw err;});
+      }
+      return captionsPromise;
+    },
+    get(key){return captionsCache[key];},
+    async set(key,value){
+      captionsCache[key]=value;
+      await salvaSuBackend(key,value);
+      return captionsCache[key];
+    }
+  };
+
+  init();
+
+  async function init(){
+    dati=leggiDaHTML();
+    try{
+      await window.captionService.load();
+      applicaCaption();
+    }catch(err){
+      console.error('Impossibile caricare le descrizioni condivise:',err);
+    }
+    renderIntestazioni();
+    initSelettori();
+    renderCalendario();
+    aggiornaMonthDisplay();
+  }
 
   function renderIntestazioni(){
     const fmt=new Intl.DateTimeFormat('it-IT',{weekday:'short'}),base=new Date(2024,0,1);
@@ -1589,7 +1621,12 @@
       badge.textContent=(item.symbol||'👤')+' '+(item.sender||'Sconosciuto');
       const cap=document.createElement('div');cap.className='cap';
       cap.contentEditable="true";cap.spellcheck=false;cap.textContent=item.description||'';
-      cap.addEventListener('blur',()=>{const nuovo=cap.textContent.trim();item.description=nuovo;salvaDescrizione(iso,idx,nuovo);});
+      cap.dataset.key=captionKey(iso,idx);
+      cap.addEventListener('blur',()=>{
+        const nuovo=cap.textContent.trim();
+        item.description=nuovo;
+        salvaDescrizione(iso,idx,nuovo);
+      });
       meta.appendChild(badge);meta.appendChild(cap);
       const az=document.createElement('div');az.className='riga-azioni';
       const dl=document.createElement('a');dl.className='ico-btn';dl.textContent='Scarica';dl.href=item.src;dl.download=`${iso}_foto${idx+1}.jpg`;az.appendChild(dl);
@@ -1656,8 +1693,29 @@
 
   function apriModal(src,alt){modalImg.src=src;modalImg.alt=alt;modal.classList.add('aperta');document.body.style.overflow='hidden';}
   function chiudiModal(){modal.classList.remove('aperta');modalImg.src='';document.body.style.overflow='';}
-  function salvaDescrizione(date,index,text){localStorage.setItem(`desc_${date}_${index}`,text);}
-  function caricaDescrizioni(){Object.entries(dati).forEach(([date,arr])=>{arr.forEach((item,idx)=>{const val=localStorage.getItem(`desc_${date}_${idx}`);if(val!==null)item.description=val;});});}
+  function salvaDescrizione(date,index,text){
+    const key=captionKey(date,index);
+    window.captionService.set(key,text).catch(err=>console.error('Errore nel salvataggio della descrizione:',err));
+  }
+  function applicaCaption(){Object.entries(dati).forEach(([date,arr])=>{arr.forEach((item,idx)=>{const key=captionKey(date,idx);if(Object.prototype.hasOwnProperty.call(captionsCache,key))item.description=captionsCache[key]||'';});});}
+  function captionKey(date,index){return`desc_${date}_${index}`;}
+  async function caricaDaBackend(){
+    try{
+      const res=await fetch(`${API_BASE}/captions`,{headers:{Accept:'application/json'}});
+      if(!res.ok)throw new Error(`Risposta ${res.status}`);
+      const payload=await res.json();
+      captionsCache=payload&&typeof payload==='object'?payload:{};
+    }catch(err){
+      captionsCache={};
+      throw err;
+    }
+    return captionsCache;
+  }
+  async function salvaSuBackend(key,value){
+    const body=JSON.stringify({key,caption:value});
+    const res=await fetch(`${API_BASE}/captions`,{method:'POST',headers:{'Content-Type':'application/json','Accept':'application/json'},body});
+    if(!res.ok)throw new Error(`Salvataggio non riuscito (${res.status})`);
+  }
   function byId(id){return document.getElementById(id);}
   function toISO(d){d.setHours(12,0,0,0);return d.toISOString().slice(0,10);}
   function toDate(iso){return new Date(iso+'T12:00:00');}
@@ -1670,27 +1728,24 @@
 })();
 </script>
 <script>
-  (function () {
-    const STORAGE_KEY = "photo_captions_v1";
-  
-    // Load previously saved captions
-    const saved = JSON.parse(localStorage.getItem(STORAGE_KEY) || "{}");
-  
-    // For every figcaption with a data-key
-    document.querySelectorAll("figcaption[contenteditable][data-key]").forEach(el => {
-      const key = el.dataset.key;
-      // If we have a saved caption, put it back
-      if (saved[key]) el.textContent = saved[key];
-  
-      // When you type something and stop
-      el.addEventListener("input", () => {
-        saved[key] = el.textContent.trim();
-        // Save all captions again to localStorage
-        localStorage.setItem(STORAGE_KEY, JSON.stringify(saved));
+  (async function(){
+    if(!window.captionService)return;
+    try{
+      await window.captionService.load();
+    }catch(err){
+      console.error('Impossibile sincronizzare le descrizioni globali:',err);
+    }
+    document.querySelectorAll('figcaption[contenteditable][data-key]').forEach(el=>{
+      const key=el.dataset.key;
+      const saved=window.captionService.get(key);
+      if(typeof saved==='string')el.textContent=saved;
+      el.addEventListener('blur',()=>{
+        const val=el.textContent.trim();
+        window.captionService.set(key,val).catch(err=>console.error('Errore nel salvataggio della descrizione:',err));
       });
     });
   })();
   </script>
-  
+
 </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "piccolamim-gallery",
+  "version": "1.0.0",
+  "description": "Galleria con backend leggero per le descrizioni condivise",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js"
+  },
+  "dependencies": {
+    "express": "^4.19.2"
+  }
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,66 @@
+const express = require('express');
+const path = require('path');
+const fs = require('fs/promises');
+
+const app = express();
+const PORT = process.env.PORT || 3000;
+const DATA_DIR = path.join(__dirname, 'data');
+const DATA_FILE = path.join(DATA_DIR, 'captions.json');
+const MAX_CAPTION_LENGTH = 2000;
+
+app.use(express.json({ limit: '1mb' }));
+app.use(express.static(__dirname));
+
+app.get('/api/captions', async (req, res) => {
+  try {
+    const captions = await readCaptions();
+    res.json(captions);
+  } catch (err) {
+    console.error('Unable to read captions:', err);
+    res.status(500).json({ error: 'Impossibile leggere le descrizioni salvate.' });
+  }
+});
+
+app.post('/api/captions', async (req, res) => {
+  const { key, caption } = req.body || {};
+  if (typeof key !== 'string' || !key.trim()) {
+    return res.status(400).json({ error: 'Chiave mancante o non valida.' });
+  }
+  const safeKey = key.trim();
+  const safeCaption = typeof caption === 'string' ? caption.trim().slice(0, MAX_CAPTION_LENGTH) : '';
+
+  try {
+    const captions = await readCaptions();
+    captions[safeKey] = safeCaption;
+    await writeCaptions(captions);
+    res.json({ ok: true });
+  } catch (err) {
+    console.error('Unable to save caption:', err);
+    res.status(500).json({ error: 'Impossibile salvare la descrizione.' });
+  }
+});
+
+app.listen(PORT, () => {
+  console.log(`Server in ascolto su http://localhost:${PORT}`);
+});
+
+async function readCaptions() {
+  try {
+    const raw = await fs.readFile(DATA_FILE, 'utf8');
+    const parsed = JSON.parse(raw);
+    if (parsed && typeof parsed === 'object') {
+      return parsed;
+    }
+  } catch (err) {
+    if (err.code === 'ENOENT') {
+      return {};
+    }
+    throw err;
+  }
+  return {};
+}
+
+async function writeCaptions(data) {
+  await fs.mkdir(DATA_DIR, { recursive: true });
+  await fs.writeFile(DATA_FILE, JSON.stringify(data, null, 2), 'utf8');
+}


### PR DESCRIPTION
## Summary
- add an Express server that serves the static gallery and stores captions on disk via a simple REST API
- replace localStorage caption logic with a shared caption service that calls the backend
- document the new workflow and ignore generated backend artifacts

## Testing
- npm install *(fails: registry blocked in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e22d869460832d9c370f4671e8c23a